### PR TITLE
Added ZWJ/ZWNJ; eyelash-RA proposal

### DIFF
--- a/packager/Nepali Romanized Pro.keylayout
+++ b/packager/Nepali Romanized Pro.keylayout
@@ -307,7 +307,7 @@ Based on the Nepali Romanized Keyboard layout by MPP-->
             <key code="47" output="॰"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" output="ऱ्"/>
+            <key code="50" output="ऽ"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>


### PR DESCRIPTION
- Added ZWJ (U+200D) and ZWNJ (U+200C)
- Added Eyelash-RA (aka Pareli-RA) combination [U+0931 + U+094D]
  to [CapsLock + ~]. See Unicode specification 5.0, Chapter 9.1, Rule R5.

PS: The second change is proposal only.
